### PR TITLE
update deprecated functions & fix typos

### DIFF
--- a/python/basic/ndarray.ipynb
+++ b/python/basic/ndarray.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# NDArray Tutorial\n",
     "\n",
@@ -31,13 +34,15 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'a.shape': (3L,), 'b.shape': (2L, 3L)}"
+       "{'a.shape': (3,), 'b.shape': (2, 3)}"
       ]
      },
      "execution_count": 1,
@@ -47,6 +52,9 @@
    ],
    "source": [
     "import mxnet as mx\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore', category=DeprecationWarning)  # hide deprecation warning\n",
+    "\n",
     "# create a 1-dimensional array with a python list\n",
     "a = mx.nd.array([1,2,3])\n",
     "# create a 2-dimensional array with a nested python list \n",
@@ -56,7 +64,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "or from an `numpy.ndarray` object"
    ]
@@ -65,13 +76,15 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "{'a.shape': (3L, 5L)}"
+       "{'a.shape': (3, 5)}"
       ]
      },
      "execution_count": 2,
@@ -90,7 +103,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "We can specify the element type with the option `dtype`, which accepts a numpy type. In default, `float32` is used. "
    ]
@@ -99,7 +115,9 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -125,7 +143,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "If we only know the size but not the element values, there are several functions to create arrays with initial placeholder content. "
    ]
@@ -134,7 +155,9 @@
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [],
    "source": [
@@ -151,7 +174,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Printing Arrays\n",
     "We often first convert `NDArray` to `numpy.ndarray` by the function `asnumpy` for printing. Numpy uses the following layout:\n",
@@ -164,7 +190,9 @@
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -186,7 +214,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Basic Operations\n",
     "Arithmetic operators on arrays apply *elementwise*. A new array is created and filled with the result."
@@ -196,7 +227,9 @@
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -228,7 +261,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "source": [
     "Simiar to `NumPy`, `*` is used for elementwise multiply, while matrix-matrix multiplication is left for `dot`"
@@ -238,7 +273,9 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -263,7 +300,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "The assignment operators such as `+=` and `*=` act in place to modify an existing array rather than create a new one."
    ]
@@ -272,7 +312,9 @@
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -296,7 +338,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Indexing and Slicing\n",
     "The slice operator `[]` applies on axis 0. "
@@ -306,7 +351,9 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -330,7 +377,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "We can also slice a particular axis with the method `slice_axis`"
    ]
@@ -339,7 +389,9 @@
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -362,7 +414,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Shape Manipulation \n",
     "The shape of the array can be changed as long as the size remaining the same "
@@ -372,7 +427,9 @@
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -400,16 +457,21 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
-    "Method `concatenate` stacks multiple arrays along the first dimension. (Their shapes must be the same)."
+    "Method `concat` stacks multiple arrays along a given axis. (Their shapes must be the same)."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -429,13 +491,16 @@
    "source": [
     "a = mx.nd.ones((2,3))\n",
     "b = mx.nd.ones((2,3))*2\n",
-    "c = mx.nd.concatenate([a,b])\n",
+    "c = mx.nd.concat(a,b, dim=0)\n",
     "c.asnumpy()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Reduce\n",
     "\n",
@@ -446,7 +511,9 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -468,7 +535,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "or along a particular axis"
    ]
@@ -477,7 +547,9 @@
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -492,13 +564,16 @@
     }
    ],
    "source": [
-    "c = mx.nd.sum_axis(a, axis=1)\n",
+    "c = mx.nd.sum(a, axis=1)\n",
     "c.asnumpy()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Broadcast\n",
     "We can also broadcast an array by duplicating. The following codes broadcast along axis 1"
@@ -508,7 +583,9 @@
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -535,7 +612,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "or broadcast along axes 1 and 2"
    ]
@@ -544,7 +624,9 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -577,7 +659,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Broadcast can be applied to operations such as `*` and `+`. "
    ]
@@ -586,7 +671,9 @@
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -611,7 +698,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Copies\n",
     "Data is *NOT* copied in normal assignment. "
@@ -621,7 +711,9 @@
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -643,7 +735,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "similar for function arguments passing."
    ]
@@ -652,7 +747,9 @@
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -674,7 +771,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "The `copy` method makes a deep copy of the array and its data"
    ]
@@ -683,7 +783,9 @@
    "cell_type": "code",
    "execution_count": 20,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -704,7 +806,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "The above code allocate a new NDArray and then assign to *b*. We can use the `copyto` method or the slice operator `[]` to avoid additional memory allocation"
    ]
@@ -713,7 +818,9 @@
    "cell_type": "code",
    "execution_count": 21,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -738,7 +845,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## The Advanced \n",
     "There are some advanced features in `mxnet.ndarray` which make mxnet different from other libraries. \n",
@@ -752,7 +862,9 @@
    "cell_type": "code",
    "execution_count": 22,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -779,7 +891,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "We can also explicitly specify the context when creating an array"
    ]
@@ -788,7 +903,9 @@
    "cell_type": "code",
    "execution_count": 23,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -809,7 +926,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Currently MXNet requires two arrays to sit on the same device for computation. There are several methods for copying data between devices."
    ]
@@ -818,7 +938,9 @@
    "cell_type": "code",
    "execution_count": 24,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -844,7 +966,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Serialize From/To (Distributed) Filesystems  \n",
     "There are two ways to save data to (load from) disks easily. The first way uses `pickle`. `NDArray` is pickle compatible."
@@ -854,7 +979,9 @@
    "cell_type": "code",
    "execution_count": 25,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -883,7 +1010,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "The second way is to directly dump into disk in binary format by method `save` and `load`. Besides single NDArray, we can load/save a list"
    ]
@@ -892,7 +1022,9 @@
    "cell_type": "code",
    "execution_count": 26,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -916,7 +1048,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "or a dict"
    ]
@@ -925,7 +1060,9 @@
    "cell_type": "code",
    "execution_count": 27,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
@@ -948,10 +1085,13 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "The load/save is better than pickle in two aspects\n",
-    "1. The data saved with the Python interface can be used by another lanuage binding. For example, if we save the data in python:\n",
+    "1. The data saved with the Python interface can be used by another language binding. For example, if we save the data in python:\n",
     "```python\n",
     "a = mx.nd.ones((2, 3))\n",
     "mx.save(\"temp.ndarray\", [a,])\n",
@@ -973,7 +1113,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "### Lazy Evaluation and Auto Parallelization *\n",
     "\n",
@@ -989,6 +1132,8 @@
    "execution_count": 28,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": true
    },
    "outputs": [
@@ -997,9 +1142,9 @@
      "output_type": "stream",
      "text": [
       "time for all computations are pushed into the backend engine:\n",
-      " 0.001089 sec\n",
+      " 0.001228 sec\n",
       "time for all computations are finished:\n",
-      " 5.398588 sec\n"
+      " 1.819054 sec\n"
      ]
     }
    ],
@@ -1025,7 +1170,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Besides analyzing data read and write dependencies, the backend engine is able to schedule computations with no dependency in parallel. For example, in the following codes\n",
     "```python\n",
@@ -1039,9 +1187,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 31,
    "metadata": {
     "collapsed": false,
+    "deletable": true,
+    "editable": true,
     "scrolled": true
    },
    "outputs": [
@@ -1049,8 +1199,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time to finish the CPU workload: 1.089354 sec\n",
-      "Time to finish both CPU/CPU workloads: 2.663608 sec\n"
+      "Time to finish the CPU workload: 0.088378 sec\n",
+      "Time to finish both CPU & GPU workloads: 0.535441 sec\n"
      ]
     }
    ],
@@ -1065,12 +1215,15 @@
     "print('Time to finish the CPU workload: %f sec' % (time.time() - tic))\n",
     "d = do(b, n)\n",
     "wait(d)\n",
-    "print('Time to finish both CPU/CPU workloads: %f sec' % (time.time() - tic))"
+    "print('Time to finish both CPU & GPU workloads: %f sec' % (time.time() - tic))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "Now we issue all workloads at the same time. The backend engine will try to parallel the CPU and GPU computations."
    ]
@@ -1079,14 +1232,16 @@
    "cell_type": "code",
    "execution_count": 30,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Both as finished in: 1.543902 sec\n"
+      "Both as finished in: 0.437928 sec\n"
      ]
     }
    ],
@@ -1102,7 +1257,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Current Status\n",
     "\n",
@@ -1123,21 +1281,21 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updates on this PR:
1. Change deprecated `concatenate` to `concat`.
`concatenate` is deprecated according to latest API doc 
http://mxnet.io/api/python/ndarray.html#mxnet.ndarray.concatenate
2. Change deprecated `sum_axis` to `sum`. 
`sum_axis is deprecated according to https://github.com/dmlc/mxnet/blob/master/docs/architecture/release_note_0_9.md#miscellaneous
3. Fix few typos: lanuage, CPU/CPU
