### PR TITLE
read binary file in python 3

### DIFF
--- a/python/basic/advanced_img_io.ipynb
+++ b/python/basic/advanced_img_io.ipynb
@@ -136,7 +136,7 @@
     "# mx.image\n",
     "tic = time.time()\n",
     "for i in range(N):\n",
-    "    img = mx.image.imdecode(open('test_images/ILSVRC2012_val_00000001.JPEG').read())\n",
+    "    img = mx.image.imdecode(open('test_images/ILSVRC2012_val_00000001.JPEG','rb').read())\n",
     "mx.nd.waitall()\n",
     "print(N/(time.time()-tic), 'images decoded per second with mx.image')\n",
     "plt.imshow(img.asnumpy()); plt.show()"


### PR DESCRIPTION
open('test_images/ILSVRC2012_val_00000001.JPEG').read() 
Creates the following error in python 3 as it decodes it wrongly:
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 0: invalid start byte
Proposed fixed:
mx.image.imdecode(open('test_images/ILSVRC2012_val_00000001.JPEG','rb').read())